### PR TITLE
Run Klondike.SelfHost.exe not interactively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,16 @@ ENV KLONDIKE_VERSION=v2.0.0
 ENV KLONDIKE_BUILD=2.0.0.26c3df25-build144
 
 RUN apt-get update && \
-    apt-get install wget unzip && \
+    apt-get install wget unzip mono-4.0-service && \
     rm -rf /var/cache/apt/*
 
-WORKDIR /app
 
-RUN wget https://github.com/themotleyfool/Klondike/releases/download/${KLONDIKE_VERSION}/Klondike.${KLONDIKE_BUILD}.zip -O /app/Klondike.${KLONDIKE_BUILD}.zip && \
+RUN mkdir /app && cd /app && wget https://github.com/themotleyfool/Klondike/releases/download/${KLONDIKE_VERSION}/Klondike.${KLONDIKE_BUILD}.zip -O /app/Klondike.${KLONDIKE_BUILD}.zip && \
     unzip *.zip
 
 EXPOSE 8080
 
 COPY Settings.config /app/Settings.config
 
-CMD ["mono", "./bin/Klondike.SelfHost.exe", "--interactive", "--port=8080"]
+WORKDIR /app/bin
+CMD ["mono", "/usr/lib/mono/4.5/mono-service.exe", "./Klondike.SelfHost.exe", "--port=8080"]

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Docker container to run a Self Hosted version of [Klondike](https://github.com/t
 
 ## Getting Started
 
-        docker run -it -d \
+        docker run -d \
                    -p 8080:8080 \
                    --name klondike
                    athieriot/docker-klondike
 
 ## Persist Package directory
 
-        docker run -it -d \
+        docker run -d \
                    -p 8080:8080 \
                    -v /path/to/packages/:/app/App_Data/Packages
                    --name klondike \
@@ -21,7 +21,7 @@ Docker container to run a Self Hosted version of [Klondike](https://github.com/t
 
 ## Override configuration            
 
-        docker run -it -d \
+        docker run -d \
                    -p 8080:8080 \
                    -v /path/to/Settings.config:/app/Settings.config \
                    -v /path/to/Web.config:/app/Web.config \


### PR DESCRIPTION
First of all: thank you for the working docker image! 

I had trouble, however, running it not interactively, with `docker-compose up -d`. It started fine, but after a few seconds exited (with exit status 0). So I followed the instructions from:
https://github.com/themotleyfool/Klondike/blob/master/src/Klondike.SelfHost/README.md so that it runs not interactively by default.

Would you consider merging it?
